### PR TITLE
save _oldvisit function in _brain object

### DIFF
--- a/lib/tarantula.js
+++ b/lib/tarantula.js
@@ -52,12 +52,12 @@ var Tarantula = function(brain) {
     if (!brain.isSeen) {
 	var seen = [];
 	
-	var _oldVisit = this._brain.visit;
+	this._oldVisit = this._brain.visit;
 	this._brain.visit = function(request, response, body, $) {
 	    seen.push(request.uri);
 	    if (this.debug)
 		console.log('Saw: ' + request.uri);
-	    _oldVisit(request, response, body, $);
+	    this._oldVisit(request, response, body, $);
 	};
     }	
 };


### PR DESCRIPTION
I wanted to be able to use custom functions within the visit-method. In order to be able to do this to the external brain-object in the, this change saves the _oldvisit-function in the brain-object as well, to fix scoping problems.
