### PR TITLE
Update tarantula.js

### DIFF
--- a/lib/tarantula.js
+++ b/lib/tarantula.js
@@ -52,7 +52,7 @@ var Tarantula = function(brain) {
     if (!brain.isSeen) {
 	var seen = [];
 	
-	this._oldVisit = this._brain.visit;
+	this._brain._oldVisit = this._brain.visit;
 	this._brain.visit = function(request, response, body, $) {
 	    seen.push(request.uri);
 	    if (this.debug)


### PR DESCRIPTION
Fix wrong scope for _visit function.

Dammit, I missed this issue in my last pull request. Sorry for the inconvenience. `_OldVisit` was written to the wrong scope, not to the `_brain`-object.
