### PR TITLE
catch 404 response codes

### DIFF
--- a/lib/tarantula.js
+++ b/lib/tarantula.js
@@ -119,8 +119,9 @@ Tarantula.prototype.start = function(frontier) {
 		    }
 
 		    setTimeout(callback, brain.politeness);
-		    
-		    
+		} else if (response.statusCode == 404) {
+		    debug('URL ' + uri + ' not found (404)')
+
 		} else {
 		    // TODO error handling.
 		    fatal(err);


### PR DESCRIPTION
As the Todo tag is saying, this could need improvement. This change lets you continue process the current neighbors queue, even after you got a 404 from a scraped dead link.
