### PR TITLE
Queues

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,16 @@
+{
+  "node": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "immed": true,
+  "newcap": true,
+  "noarg": true,
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true
+}

--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
 # node-tarantula
 
-nodejs crawler/spider which provides a simple interface for crawling the Web. Its API has been inspired by [crawler4j](http://http://code.google.com/p/crawler4j/).
+nodejs crawler/spider which provides a simple interface for crawling the Web. Its API has been inspired by [crawler4j](https://code.google.com/p/crawler4j/).
 
 ## Quick Examples
 
 ```js
 var brain = {
 
-    politeness: 2000,
+    leg: 8,
 
     shouldVisit: function(uri) {
         return true;
-    },
+    }
 
-    visit : function(request, response, body, $) {
-        console.log(request.uri);
-    },
-
-    debug: false
 };
 
 var tarantula = new Tarantula(brain);
+
+tarantula.on('visit', function (uri, req, resp) {
+	  console.info('200', uri);
+});
 
 tarantula.on('done', function() { 
     console.log('done'); 

--- a/example-wikidive.js
+++ b/example-wikidive.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/*global require*/
+var Tarantula = require('./lib/tarantula.js');
+
+var site = 'http://en.wikipedia.org/';
+var tarantula = new Tarantula({
+	legs: 10,
+	stayInRange: true,
+	modRequest: function (req) {
+		req.headers.userAgent = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0';
+		return req;
+	}
+});
+console.log('Crawling… ', site);
+tarantula.on('request', function (uri) {
+	console.log('GET', uri);
+});
+tarantula.on('visit', function (uri) {
+	console.info('200', uri);
+});
+tarantula.on('uris', function (newCount, newTotal) {
+	console.log(newTotal + ' (+' + newCount +')');
+});
+tarantula.on('error', function (errorCode, uri, req, resp) {
+	console.error(errorCode || 'ERR', uri, req, resp);
+});
+tarantula.on('done', function () {
+	console.info('done');
+});
+
+tarantula.start([site]);

--- a/lib/tarantula.js
+++ b/lib/tarantula.js
@@ -1,142 +1,139 @@
+'use strict';
 var request = require('request');
 var cheerio = require('cheerio');
 var events = require('events');
-var url = require('url');
 var async = require('async');
+var url = require('url');
+var _ = require('lodash');
 
-var Tarantula = function(brain) {
-
-    // default brain.
-    this._brain = {
-	politeness: 2000,
-	// TODO event maybe?
-	visit: function(request, response, body, $) {
-	    if (this.debug)
-		console.log('Visits: ' + request.uri);
-	},
-	isSeen: function(uri) {
-	    return seen.indexOf(uri) != -1;;
-	},
-	shouldVisit: function(uri) {
-	    if (this.debug)
-		console.log('Test should visit: ' + uri);
-	    return true;
-	},
-	makeRequest: function(uri) {
-	    return {uri: uri, headers: {'User-Agent': 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'} };
-	},
-
-	nbh: function(base, $) {
-	    var nbh = [];
-	    $('a').each(function() {
-		var l = $(this).attr('href');
-		if (typeof l === 'string') {
-		    
-		    // trim hashtags.
-		    var indexOfHash = l.indexOf("#");
-		    if (indexOfHash != -1)
-			l = l.substring(0, indexOfHash);
-		    // TODO other protocols? Error handling?
-		    var resolved = url.resolve(base, l);
-		    nbh.push(resolved);
-		}
-	    });
-
-	    return nbh;
-	},
-    };
-
-    // extend.
-    for (var x in brain) this._brain[x] = brain[x];
-	
-    if (!brain.isSeen) {
-	var seen = [];
-	
-	this._brain._oldVisit = this._brain.visit;
-	this._brain.visit = function(request, response, body, $) {
-	    seen.push(request.uri);
-	    if (this.debug)
-		console.log('Saw: ' + request.uri);
-	    this._oldVisit(request, response, body, $);
-	};
-    }	
+var Tarantula = function (brain) {
+	// extend defaults
+	this.brain = {};
+	for (var i in Tarantula.DefaultBrain) {
+		this.brain[i] = (brain && typeof brain[i] !== 'undefined') ? brain[i] : Tarantula.DefaultBrain[i];
+	}
 };
+Tarantula.DefaultBrain = {
+	// {int} Max number of connections
+	legs: 10,
+	// {bool} If we should remove '#' Anchors from links
+	trimHashes: true,
+	// {bool} If we should skip Duplicate URI's we see
+	skipDupes: true,
+	// {bool} If we should stay on the base url path
+	stayInRange: false,
+	// {string} User agent to use in requests
+	userAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0',
+	// {function} How to gather links from a page
+	visit: function (uri, request, response, body, $) {
+		var uris = _.filter($('a').toArray().map(function (elem) {
+			if (elem.attribs && typeof elem.attribs.href === 'string') {
+				return url.resolve(uri, elem.attribs.href);
+			}
+		}));
+		return uris;
+	},
+	// {function} Determine if Tarantula should visit this uri
+	shouldVisit: function (uri) {
+		if (uri) {
+			return true;
+		}
+	},
+	// {function} Use this function to modify any Headers you need
+	// @see npm request
+	modRequest: function (req) {
+		return req;
+	},
+};
+Tarantula.prototype = new events.EventEmitter();
+Tarantula.prototype.start = function (frontier) {
+	if (typeof frontier === 'string') {
+		frontier = [frontier];
+	}
+	if (!_.isArray(frontier)) {
+		throw new TypeError('Tarantula::start requires Array of URLs to crawl');
+	}
+	var tarantula = this;
+	var brain = this.brain;
+	var range = new RegExpSet(frontier);
+	var uriQ = frontier.slice(0);
+	var taskQ = async.queue(function (uri, checkIn) {
+		var req = brain.modRequest({
+			uri: uri,
+			headers: {
+				'User-Agent': brain.userAgent
+			}
+		});
 
-Tarantula.prototype = new events.EventEmitter;
+		tarantula.emit('request', uri, req);
+		request(req, receive);
 
-Tarantula.prototype.start = function(frontier) {
-    frontier = frontier || [];
-
-    var tarantula = this;
-    var brain = this._brain;
-
-    // TODO there must be some kind of logging framework out there.
-    var debug = function(obj) {
-	if (brain.debug)
-	    console.log(obj);
-    };
-
-    var fatal = function(obj) {
-	console.log(obj);
-    };
-    
-    debug('Frontier: ');
-    debug(frontier);
-
-    // frontier unseen neighbourhood.
-    var nb = [];
-    
-    async.whilst(
-	function() { return frontier.length },
-        function(callback) {
-	    
-	    var uri = frontier.pop();
-	    
-	    var rq = brain.makeRequest(uri);
-	    
-	    // TODO parallelism? Use async.
-	    request(rq, function (err, response, body) {
-		if (!err && response.statusCode == 200) {
-		    
-		    var $ = cheerio.load(body);
-		    // TODO error handling.
-		    brain.visit(rq, response, body, $);
-		    
-		    brain.nbh(rq.uri, $).forEach(function(uri) {
-			if (brain.shouldVisit(uri))
-			    if (!brain.isSeen(uri))
-				if (frontier.indexOf(uri) == -1 && nb.indexOf(uri) == -1) {
-				    debug('Add to neighbourhood: ' + uri);
-				    nb.push(uri);
+		function receive (err, resp, body) {
+			if (!err && resp.statusCode == 200) {
+				tarantula.emit('visit', uri, req, resp);
+				var $ = cheerio.load(body);
+				// TODO error handling.
+				var uris = brain.visit(uri, req, resp, body, $);
+				if (!_.isArray(uris)) {
+					throw new TypeError('brain::visit did not yield an array');
 				}
-		    });
-		    
-		    if (!frontier.length) {
-			debug('Frontier: ');
-			debug(nb);
-			frontier = nb;
-			nb = [];
-		    }
-
-		    setTimeout(callback, brain.politeness);
-		} else if (typeof response != 'undefined' 
-				&& response.statusCode == 404) {
-		    debug('URL ' + uri + ' not found (404)')
-
-		} else {
-		    // TODO error handling.
-		    fatal(err);
+				if (brain.trimHashes) {
+					uris = uris.map(trimHash);
+				}
+				if (brain.skipDupes) {
+					uris = _.difference(_.unique(uris), uriQ);
+				}
+				if (brain.stayInRange) {
+					uris = uris.filter(range.test);
+				}
+				if (brain.shouldVisit) {
+					uris = uris.filter(brain.shouldVisit);
+				}
+				if (uris.length) {
+					uriQ.push.apply(uriQ, uris);
+					taskQ.push(uris);
+				}
+				tarantula.emit('uris', uris.length, uriQ.length, uri, req, resp);
+			}
+			else {
+				var errorCode = resp && resp.statusCode;
+				tarantula.emit('error', errorCode, uri, req, resp);
+			}
+			checkIn();
 		}
-	    });
-	},
-	function(err) {
-	    if (err)
-		fatal(err);
-
-	    tarantula.emit('done');
-	});
-    
-
+	}, brain.legs);
+	taskQ.drain = function () {
+		tarantula.emit('done');
+	};
+	taskQ.push(uriQ);
 };
+function RegExpSet (arr) {
+	for (var i = 0; i < arr.length; i++) {
+		this.push(new RegExp(arr[i]));
+	}
+	this.test = this.test.bind(this);
+}
+RegExpSet.prototype = [];
+RegExpSet.prototype.test = function (str) {
+	for (var i = 0; i < this.length; i++) {
+		if (this[i].test(str)) {
+			return true;
+		}
+	}
+	return false;
+};
+
+/**
+ * Remove Hash part of a URL
+ *
+ * @param {string} uri
+ *   The URL to remove hash from
+ * @param {string}
+ *   The URL without hash
+ */
+function trimHash (uri) {
+	var indexOfHash = uri.indexOf('#');
+	return (indexOfHash != -1) ? uri.substring(0, indexOfHash) : uri;
+}
 
 module.exports = Tarantula;

--- a/package.json
+++ b/package.json
@@ -1,22 +1,30 @@
 {
-  "name" : "tarantula",
-  "description" : "nodejs crawler/spider which provides a simple interface for crawling the Web",
-  "version" : "0.0.5",
-  "author" : "George Politis <gp@superpointer.com>",
-  "engines" : ["node"],
-  "directories" : { 
-    "lib" : "./lib" 
+  "name": "tarantula",
+  "description": "nodejs crawler/spider which provides a simple interface for crawling the Web",
+  "version": "0.0.5",
+  "author": "George Politis <gp@superpointer.com>",
+  "engines": [
+    "node"
+  ],
+  "directories": {
+    "lib": "./lib"
   },
-  "main" : "./lib/tarantula",
-  "repository" : { "type":"git", "url":"https://github.com/gpolitis/node-tarantula.git" },
-  "licenses" : [ { "type" : "MIT"
-      , "url" : "http://github.com/gpolitis/node-tarantula/raw/master/LICENSE"
+  "main": "./lib/tarantula",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gpolitis/node-tarantula.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/gpolitis/node-tarantula/raw/master/LICENSE"
     }
   ],
-  "dependencies" : {
-    "request" : "",
-    "cheerio" : "",
-    "async": ""
+  "dependencies": {
+    "request": "",
+    "cheerio": "",
+    "async": "",
+    "lodash": "~2.4.1"
   },
   "keywords": [
     "spider",


### PR DESCRIPTION
This involves some pretty big changes to the interface.
1. Firstly, there is thread concurrency through on async's queues.  We can pass in the max amount of concurrency, which I've named "legs" to keep with our fun alias'ing scheme.  I believe this negates the need for "politeness", but we could add that back.
2. There are a lot more events to listen to.  You can use the example-wikipedia to preview them all.  This helps us push our concerns about console off to the implementor.
3. There is an option to "stayInRange" which will keep us on a single domain (common use-case, I believe).  It's a bit more extensible than a "domain", because use can pass in a url with a path, or a series of url's with path.  Then it won't leave that folder range.

Next steps:
- I'd like to mod code the a bit more OO.  Putting the core methods on Tarantula's prototype, and letting implementors override them.  This will change the interface a bit more, but it will help alleviate the deep nesting, and result in concise functions.
- I'd like to add an optional PhantomJS backend.  This is actually my core motivation.  Other PhantomJS-based crawlers have somewhat painful interfaces.
