### PR TITLE
Update PhantomClient.js

### DIFF
--- a/lib/client/PhantomClient.js
+++ b/lib/client/PhantomClient.js
@@ -3,6 +3,7 @@
 var PhantomJS = require('node-phantom-simple');
 
 function PhantomClient () {
+	this.requestSettings = {};
 	this.headers = {};
 	this.getData = function () {};
 	this.listener = function () {};


### PR DESCRIPTION
fix requestSettings in PhantomClient.js
this commit fixes error message "Cannot set property 'ignore-ssl-errors' of undefined" when I run example-wikidive-phantom.js
